### PR TITLE
Move yaml files inside of the tar to a root of the tar

### DIFF
--- a/assembly/build.sh
+++ b/assembly/build.sh
@@ -13,6 +13,8 @@ if [ ! -f ../ui/hello_world_plugin.theia ]; then
 fi
 
 tar cvf che-dummy-plugin.tar -C ../ui hello_world_plugin.theia
-tar uvf che-dummy-plugin.tar etc
+cd etc
+tar uvf ../che-dummy-plugin.tar .
+cd ..
 gzip che-dummy-plugin.tar
 


### PR DESCRIPTION
Moving of files is needed because spec of the plugin broker says that those files should be in the root of a tar.